### PR TITLE
Remove unused and invalid imports

### DIFF
--- a/ContextPose/mvn/datasets/human36m.py
+++ b/ContextPose/mvn/datasets/human36m.py
@@ -1,21 +1,16 @@
 import os
 import collections
 from collections import defaultdict
-from time import time
 import pickle
-import random
 
 import numpy as np
 np.set_printoptions(suppress=True)
 import cv2
 
-import torch
 from torch.utils.data import Dataset
 
 from mvn.models.loss import MPJPE, P_MPJPE, N_MPJPE, MPJVE
-from mvn.utils.multiview import Camera, project_3d_points_to_image_plane_without_distortion
-from mvn.utils.img import get_square_bbox, resize_image, crop_image, normalize_image, scale_bbox, erase_image
-from mvn.utils import volumetric
+from mvn.utils.img import crop_image
 
 retval = {
     'subject_names': ['S1', 'S5', 'S6', 'S7', 'S8', 'S9', 'S11'],

--- a/ContextPose/mvn/datasets/human36m_preprocessing/limb_length.py
+++ b/ContextPose/mvn/datasets/human36m_preprocessing/limb_length.py
@@ -1,13 +1,9 @@
 import _init_path
-from mvn import datasets
 from mvn.utils.cfg import config, update_config
 import numpy as np
 
-from easydict import EasyDict as edict
-import yaml
 import os
 import sys
-import time
 from tqdm import tqdm
 import h5py
 

--- a/ContextPose/mvn/datasets/human36m_preprocessing/undistort-h36m.py
+++ b/ContextPose/mvn/datasets/human36m_preprocessing/undistort-h36m.py
@@ -3,7 +3,6 @@
 
     Usage: `python3 undistort-h36m.py <path/to/Human3.6M-root> <path/to/human36m-multiview-labels.npy> <num-processes>`
 """
-import torch
 import numpy as np
 import cv2
 from tqdm import tqdm

--- a/ContextPose/mvn/datasets/human36m_preprocessing/view-dataset.py
+++ b/ContextPose/mvn/datasets/human36m_preprocessing/view-dataset.py
@@ -5,8 +5,6 @@
 
     Usage: `python3 view-dataset.py <path/to/Human3.6M-root> <path/to/human36m-multiview-labels-*bboxes.npy> [<start-sample-number> [<samples-per-step>]]
 """
-import torch
-import numpy as np
 import cv2
 
 import os, sys
@@ -53,6 +51,7 @@ while True:
 
     display = image.copy()
 
+    # Invalid Import! Non-existant function is being used.
     from mvn.utils.multiview import project_3d_points_to_image_plane_without_distortion as project
     keypoints_2d = project(camera.projection, sample['keypoints_3d'][:, :3])
     

--- a/ContextPose/mvn/datasets/utils.py
+++ b/ContextPose/mvn/datasets/utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import torch
 
-from mvn.utils.multiview import project_3d_points_to_image_plane_without_distortion
 from mvn.utils.img import image_batch_to_torch
 
 import os

--- a/ContextPose/mvn/models/conpose.py
+++ b/ContextPose/mvn/models/conpose.py
@@ -1,20 +1,7 @@
-from copy import deepcopy
-import numpy as np
-import pickle
-import random
-from time import time
-
-from scipy.optimize import least_squares
-
 import torch
 from torch import nn
-import torch.nn.functional as F
 
-from mvn.utils import op, multiview, img, misc, volumetric
-
-from mvn.models import pose_hrnet, pose_resnet
-from mvn.models.networks import network
-from mvn.models.cpn.test_config import cfg
+from mvn.models import pose_hrnet
 from mvn.models.pose_dformer import PoseTransformer
 
 

--- a/ContextPose/mvn/models/cpn/test.py
+++ b/ContextPose/mvn/models/cpn/test.py
@@ -1,14 +1,9 @@
 import os
-import sys
 import argparse
-import time
-import matplotlib.pyplot as plt
 
 import torch
 import torch.nn.parallel
-import torch.backends.cudnn as cudnn
 import torch.optim
-import torchvision.datasets as datasets
 import cv2
 import json
 import numpy as np
@@ -16,11 +11,7 @@ import numpy as np
 from test_config import cfg
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
-from utils.logger import Logger
-from utils.evaluation import accuracy, AverageMeter, final_preds
-from utils.misc import save_model, adjust_learning_rate
-from utils.osutils import mkdir_p, isfile, isdir, join
-from utils.transforms import fliplr, flip_back
+from utils.osutils import mkdir_p, isdir
 from utils.imutils import im_to_numpy, im_to_torch
 from networks import network 
 from dataloader.mscocoMulti import MscocoMulti

--- a/ContextPose/mvn/models/cpn/train.py
+++ b/ContextPose/mvn/models/cpn/train.py
@@ -11,10 +11,9 @@ import torchvision.datasets as datasets
 
 from config import cfg
 from utils.logger import Logger
-from utils.evaluation import accuracy, AverageMeter, final_preds
+from utils.evaluation import AverageMeter
 from utils.misc import save_model, adjust_learning_rate
 from utils.osutils import mkdir_p, isfile, isdir, join
-from utils.transforms import fliplr, flip_back
 from networks import network 
 from dataloader.mscocoMulti import MscocoMulti
 

--- a/ContextPose/mvn/models/networks/network.py
+++ b/ContextPose/mvn/models/networks/network.py
@@ -1,6 +1,5 @@
 from .resnet import *
 import torch.nn as nn
-import torch
 from .globalNet import globalNet
 from .refineNet import refineNet
 

--- a/ContextPose/mvn/models/networks/refineNet.py
+++ b/ContextPose/mvn/models/networks/refineNet.py
@@ -1,5 +1,4 @@
 import torch.nn as nn
-import torch
 
 class Bottleneck(nn.Module):
     expansion = 4

--- a/ContextPose/mvn/models/pose_dformer.py
+++ b/ContextPose/mvn/models/pose_dformer.py
@@ -1,20 +1,15 @@
 ## Our PoseFormer model was revised from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py
 
 import math
-import logging
 from functools import partial
-from collections import OrderedDict
-from einops import rearrange, repeat
+from einops import rearrange
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.init import constant_
 
-import numpy as np
-
-from timm.models.layers import DropPath, to_2tuple, trunc_normal_
-from timm.models.registry import register_model
+from timm.models.layers import DropPath
 
 
 class Mlp(nn.Module):

--- a/ContextPose/mvn/utils/cfg.py
+++ b/ContextPose/mvn/utils/cfg.py
@@ -1,6 +1,5 @@
 import yaml
 from easydict import EasyDict as edict
-import numpy as np
 import os
 
 config = edict()

--- a/ContextPose/mvn/utils/misc.py
+++ b/ContextPose/mvn/utils/misc.py
@@ -1,9 +1,5 @@
-import os
 import yaml
 import json
-import re
-
-import torch
 
 
 def config_to_str(config):

--- a/ContextPose/train.py
+++ b/ContextPose/train.py
@@ -2,21 +2,12 @@ import os
 import shutil
 import argparse
 import time
-import json
 from datetime import datetime
 from collections import defaultdict
-from itertools import islice
-import pickle
-import copy
-from tqdm import tqdm
-from PIL import Image
 import numpy as np
 np.set_printoptions(suppress=True)
-import cv2
 
 import torch
-from torch import nn
-from torch import autograd
 import torch.nn.functional as F
 import torch.optim as optim
 from torch.utils.data import DataLoader
@@ -25,14 +16,11 @@ from torch.nn.parallel import DistributedDataParallel
 from tensorboardX import SummaryWriter
 
 from mvn.models.conpose import VolumetricTriangulationNet
-from mvn.models.loss import MPJPE, KeypointsMSELoss, KeypointsMSESmoothLoss, KeypointsMAELoss, KeypointsL2Loss, VolumetricCELoss, LimbLengthError
+from mvn.models.loss import MPJPE, KeypointsMSELoss, KeypointsMSESmoothLoss, KeypointsMAELoss
 
-from mvn.utils import img, multiview, op, vis, misc, cfg
-from mvn.utils.logger import Logger
+from mvn.utils import misc
 from mvn.utils.cfg import config, update_config, update_dir
-from mvn import datasets
 from mvn.datasets import utils as dataset_utils
-from mvn.utils.vis import JOINT_NAMES_DICT
 
 
 joints_left = [4, 5, 6, 11, 12, 13] 


### PR DESCRIPTION
This pull requests removes the majority of unused and invalid imports causing the code to crash.
Some files try to get imported (multiview, evaluation, osutils, etc...) but they do not exist.
After looking a little further, these files seem to have been removed in commit e4c4f0bb05a093f9c67fbbcad9720b46bfcc410d.
By removing the invalid imports, the code is able to run again out of the box.

To Note:
Some invalid imports still remain in this branch. This is because they use the imported functions in the code.
This can probably be fixed by restoring the deleted files.
Affected lines:
mvn/models/cpn/train.py L14 L16 L18
mvn/datasets/human36m_preprocessing L55
mvn/models/cpn/test.py L14 L15 L17